### PR TITLE
Add ToolTip functionality

### DIFF
--- a/system/sys/appserver/libsyllable/Makefile
+++ b/system/sys/appserver/libsyllable/Makefile
@@ -17,7 +17,7 @@ OBJS	= rect.o region.o desktop.o bitmap.o view.o tabview.o			\
 	  listview.o requesters.o layoutview.o			\
 	  radiobutton.o filerequester.o dropdownmenu.o checkmenu.o splitter.o \
 	  image.o imageview.o imagebutton.o treeview.o \
-      popupmenu.o iconview.o icondirview.o statusbar.o toolbar.o separator.o inputbox.o
+      popupmenu.o iconview.o icondirview.o statusbar.o toolbar.o separator.o inputbox.o tooltip.o
 
 OBJS += colorselector.o colorview.o colorwheel.o gradientview.o
 OBJS += fontrequester.o fontrequesterview.o

--- a/system/sys/appserver/libsyllable/gui/view.cpp
+++ b/system/sys/appserver/libsyllable/gui/view.cpp
@@ -32,7 +32,7 @@
 #include <gui/stringview.h>
 #include <gui/font.h>
 #include <gui/bitmap.h>
-
+#include <gui/tooltip.h>
 #include <appserver/protocol.h>
 
 #include <macros.h>
@@ -122,9 +122,10 @@ static Color32_s Tint( const Color32_s & sColor, float vTint )
 
 class View::Private
 {
-      public:
+public:
 	int m_hViewHandle;	// Our bridge to the server
-	port_id m_hReplyPort;	// Used as reply address when talking to server
+	port_id m_hToolTipPort;	// Used as reply address when talking to server
+
 	View *m_pcTopChild;
 	View *m_pcBottomChild;
 
@@ -137,6 +138,7 @@ class View::Private
 
 	ScrollBar *m_pcHScrollBar;
 	ScrollBar *m_pcVScrollBar;
+	ToolTip* m_pcToolTip;
 	Rect m_cFrame;
 	Point m_cScrollOffset;
 	String m_cTitle;
@@ -182,7 +184,7 @@ View::View( const Rect & cFrame, const String & cTitle, uint32 nResizeMask, uint
 {
 	m = new Private;
 
-	m->m_hReplyPort = create_port( "view_reply", DEFAULT_PORT_SIZE );
+	m->m_hToolTipPort = create_port( "tooltip_reply", DEFAULT_PORT_SIZE );
 
 	m->m_pcContextMenu = NULL;
 
@@ -215,6 +217,7 @@ View::View( const Rect & cFrame, const String & cTitle, uint32 nResizeMask, uint
 
 	m->m_pcHScrollBar = NULL;
 	m->m_pcVScrollBar = NULL;
+	m->m_pcToolTip = NULL;
 
 	m->m_nTabOrder = -1;
 	m->m_sBgColor = get_default_color( COL_NORMAL );
@@ -275,7 +278,7 @@ View::~View()
 		m->m_pcParent->RemoveChild( this );
 	}
 	_ReleaseFont();
-	delete_port( m->m_hReplyPort );
+	delete_port( m->m_hToolTipPort );
 	delete m;
 }
 
@@ -1781,6 +1784,17 @@ void View::ClearShapeRegion()
 	psCmd->m_nClipCount = -1;
 	pcWindow->_PutRenderCmd();
 	Flush();
+}
+
+void View::SetToolTip(const os::String& t) const
+{
+	m->m_pcToolTip = new ToolTip(t.c_str());
+	m->m_pcToolTip->Start();
+}
+
+os::String View::GetToolTip() const
+{
+	return m->m_pcToolTip->GetTip();
 }
 
 

--- a/system/sys/appserver/libsyllable/gui/view.cpp
+++ b/system/sys/appserver/libsyllable/gui/view.cpp
@@ -1235,6 +1235,13 @@ uint32 View::GetQualifiers() const
 
 void View::MouseMove( const Point & cNewPos, int nCode, uint32 nButtons, Message * pcData )
 {
+	if (nCode == MOUSE_INSIDE && m->m_pcToolTip != NULL)
+	{
+		os::Point p = ConvertToScreen(cNewPos);
+		m->m_pcToolTip->MoveTo(p);
+		m->m_pcToolTip->ShowTip();
+	}
+
 	Window *pcWnd = GetWindow();
 
 	if( pcWnd != NULL )

--- a/system/sys/include/gui/view.h
+++ b/system/sys/include/gui/view.h
@@ -267,6 +267,9 @@ public:
     View*		GetParent() const;
     ScrollBar*		GetVScrollBar() const;
     ScrollBar*		GetHScrollBar() const;
+	void			SetToolTip(const os::String& t) const;
+	os::String 		GetToolTip() const;
+
     Window*		GetWindow() const { return( (Window*)GetLooper() ); }
     String		GetTitle() const;
 


### PR DESCRIPTION

Add ToolTip functionality to os::View.  The UI on this needs to be updated with libcario once we are merging that in.

Note: This only works if the View hasn't overwritten View::MouseMove without including View::MouseMove, this will be fixed in a future version but for now this shows that tooltips are possible.