### PR TITLE
Rename libsyllable to libos

### DIFF
--- a/system/sys/appserver/libsyllable/Makefile
+++ b/system/sys/appserver/libsyllable/Makefile
@@ -6,7 +6,7 @@ CATALOGS = da de es fr hu nl pl pt-br ru sv
 
 LIBBIN = /system/libraries
 
-LIBNAME = libsyllable.so.7
+LIBNAME = libos.so.1
 
 VPATH = ./ gui storage util translation gui/colorselector gui/fontrequester
 
@@ -62,7 +62,7 @@ deps: $(OBJDIR) catalogs $(DEPS)
 
 install: $(OBJDIR)/$(LIBNAME)
 	install -s $(OBJDIR)/$(LIBNAME) $(IMAGE)/$(LIBBIN)/$(LIBNAME)
-	ln -sf $(LIBNAME) $(IMAGE)/$(LIBBIN)/libsyllable.so
+	ln -sf $(LIBNAME) $(IMAGE)/$(LIBBIN)/libos.so
 	cp catalogs/libsyllable.catalog $(IMAGE)/system/resources/catalogs/
 	for CATALOG in $(CATALOGS); do \
 		echo $$CATALOG; \

--- a/system/sys/appserver/libsyllable/gallery/makefile
+++ b/system/sys/appserver/libsyllable/gallery/makefile
@@ -29,7 +29,7 @@ objs:
 
 "WidgetGallery": $(OBJS)
 	@echo Linking...
-	@$(CXX) $(OBJS) -o "WidgetGallery"  -lsyllable -lstdc++
+	@$(CXX) $(OBJS) -o "WidgetGallery"  -los -lstdc++
 	@echo Adding resources...
 	@rescopy "WidgetGallery" -r resources/icons/*
 	@addattrib "WidgetGallery" os::Category Other


### PR DESCRIPTION
Rename libsyllable to libos.  This has not been done for apps at it is not ready for primetime yet, but this makes it easier to deploy new versions to test.